### PR TITLE
修正畫面細節

### DIFF
--- a/src/components/Main/ProfileEditModal.jsx
+++ b/src/components/Main/ProfileEditModal.jsx
@@ -136,7 +136,10 @@ const ProfileEditModal = (props) => {
     <Modal size="lg" show={show} onHide={handleClose}>
       <ModalStyle>
         <Modal.Header>
-          <CloseOrangeIcon style={{ cursor: "pointer" }} />
+          <CloseOrangeIcon
+            style={{ cursor: "pointer" }}
+            onClick={handleClose}
+          />
           <div className="title-wrap">
             <Modal.Title>編輯個人資料</Modal.Title>
             <Button variant="primary" size="sm" onClick={handleClose}>

--- a/src/components/Main/UserInfoArea.jsx
+++ b/src/components/Main/UserInfoArea.jsx
@@ -46,9 +46,7 @@ const CardStyle = styled.div`
     .text-wrap {
       display: flex;
       gap: 2rem;
-      a {
-        color: var(--secondary-color) !important;
-      }
+      color: var(--secondary-color) !important;
     }
   }
 `;
@@ -118,7 +116,10 @@ function UserInfoArea(props) {
       <img className="avatar" src={avatar} alt="avatar" />
       <div className="card-header">
         {UserId === "self" ? (
-          <Button variant="outline-primary ms-auto mt-4 me-4" onClick={handleShow}>
+          <Button
+            variant="outline-primary ms-auto mt-4 me-4"
+            onClick={handleShow}
+          >
             編輯個人資料
           </Button>
         ) : (
@@ -141,9 +142,13 @@ function UserInfoArea(props) {
             )}
 
             {followState === true ? (
-              <Button variant="primary" onClick={handleFollow}>正在跟隨</Button>
+              <Button variant="primary" onClick={handleFollow}>
+                正在跟隨
+              </Button>
             ) : (
-              <Button variant="outline-primary" onClick={handleFollow}>跟隨</Button>
+              <Button variant="outline-primary" onClick={handleFollow}>
+                跟隨
+              </Button>
             )}
           </ButtonStyle>
         )}
@@ -156,20 +161,20 @@ function UserInfoArea(props) {
         <div className="mb-2">{selfIntro}</div>
         <div className="text-wrap">
           <div className="text">
-            {followed}個
-            <NavLink to={`/user/${UserId}/following`}>跟隨中</NavLink>
+            <NavLink to={`/user/${UserId}/following`}>{followed}個</NavLink>
+            跟隨中
           </div>
           <div className="text">
-            {follower}位
-            <NavLink to={`/user/${UserId}/followers`}>跟隨者</NavLink>
+            <NavLink to={`/user/${UserId}/followers`}>{follower}位</NavLink>
+            跟隨者
           </div>
         </div>
       </div>
       <ProfileEditModal
         show={show}
         setShow={setShow}
-        selfImage={'https://i.imgur.com/buZlxFF.jpg'}
-        coverImage={'https://i.imgur.com/Uongp79.jpg'}
+        selfImage={"https://i.imgur.com/buZlxFF.jpg"}
+        coverImage={"https://i.imgur.com/Uongp79.jpg"}
       />
     </CardStyle>
   );

--- a/src/components/SideBar/SideBarModal.jsx
+++ b/src/components/SideBar/SideBarModal.jsx
@@ -109,10 +109,11 @@ function SideBarModal(props) {
             ) : (
               <img className="avatar" src={selfImage} alt="avatar" />
             )}
-            <InputStyle placeholder={"推你的回覆"} />
+            <InputStyle placeholder={"有什麼新鮮事?"} />
           </div>
         </Modal.Body>
         <Modal.Footer>
+          <label style={{fontSize:'13px',color:'red',marginRight:'20px'}}>字數不可超過140字</label>
           <Button variant="primary" size="sm" onClick={handleClose}>
             推文
           </Button>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -44,7 +44,7 @@ const LoginPage = () => {
           <Link to="/signup">
             <AuthLinkText>註冊</AuthLinkText>
           </Link>
-          <Link to="/adminlogin">
+          <Link to="/admin_login">
             <AuthLinkText>後台登入</AuthLinkText>
           </Link>
         </AuthLinkTextGroup>

--- a/src/pages/OtherProfileReply.jsx
+++ b/src/pages/OtherProfileReply.jsx
@@ -50,7 +50,7 @@ function OtherProfileReply() {
           {/* back為返回記號 number為推文數 */}
           <Breadcrumb title={"Doja Cat"} number={"77"} back={true} />
           <UserInfoArea
-            name={"Doja Cat"}
+            username={"Doja Cat"}
             account={"dojacat"}
             UserId={1}
             isFollowed={true}
@@ -141,7 +141,7 @@ function OtherProfileReply() {
           />
         </CenterContainer>
         <RightContainer>
-          <PopularUserList/>
+          <PopularUserList />
         </RightContainer>
       </MainStyle>
     </Container>

--- a/src/pages/OtherProfileTweets.jsx
+++ b/src/pages/OtherProfileTweets.jsx
@@ -50,7 +50,7 @@ function OtherProfileTweets() {
           {/* back為返回記號 number為推文數 */}
           <Breadcrumb title={"Doja Cat"} number={"77"} back={true} />
           <UserInfoArea
-            name={"Doja Cat"}
+            username={"Doja Cat"}
             account={"dojacat"}
             UserId={1}
             isFollowed={true}
@@ -147,7 +147,7 @@ function OtherProfileTweets() {
           />
         </CenterContainer>
         <RightContainer>
-          <PopularUserList/>
+          <PopularUserList />
         </RightContainer>
       </MainStyle>
     </Container>


### PR DESCRIPTION
1. 左邊sidebar推文按鈕按下後的modal內容
2. 編輯個人資料modal的左上X icon設定按下即關閉modal視窗
3. 原本UserInfoArea中text-wrap的連結設定在"跟隨中"和"使用者"(鼠標移至前方數字無反應)，我把它改成連結設定在前面數字
4. 原本點到他人頁面時，在"推文"和"回覆"頁面時，使用者姓名沒有顯示，將帶入UserInfoArea時的name修正為username